### PR TITLE
fix: language generation

### DIFF
--- a/page/keyboard.html
+++ b/page/keyboard.html
@@ -9,7 +9,6 @@
 </head>
 <body>
 
-    <!-- <textarea name="textarea"  id = 'textarea' class="textarea" cols="30" rows="10" autofocus ="true"></textarea> -->
 
     <script src="keyboard.js"></script>
 </body>

--- a/page/keyboard.js
+++ b/page/keyboard.js
@@ -160,22 +160,20 @@ class Keyboard {
     return this;
   };
 }
-const lan = sessionStorage.getItem('lang');
-let setting = {};
-if (lan === 'undefined') {
-  setting = {
-    currentLanguage: 'eng',
-    isLower: true,
-    isCaps: false,
-  };
+
+const setting = {
+  currentLanguage: null,
+  isLower: true,
+  isCaps: false,
+};
+
+if (!sessionStorage.getItem('keyLan')) {
+  setting.currentLanguage = 'eng';
 } else {
-  setting = {
-    currentLanguage: lan,
-    isLower: true,
-    isCaps: false,
-  };
+  setting.currentLanguage = sessionStorage.getItem('keyLan');
 }
-window.sessionStorage.setItem('lang', setting.currentLanguage);
+
+sessionStorage.setItem('keyLan', `${setting.currentLanguage}`);
 
 const nonPrintableButton = ['Tab', 'Backspace', 'CapsLock', 'Shift', 'Enter', 'Space', 'Alt', 'Delete', 'Control', 'OS', 'Ctrl', 'Del'];
 const currentKeyboard = new Keyboard([en, ru]);
@@ -227,7 +225,8 @@ const keyPress = (event) => {
     } else {
       setting.currentLanguage = 'eng';
     }
-    window.sessionStorage.setItem('lang', setting.currentLanguage);
+
+    sessionStorage.setItem('keyLan', `${setting.currentLanguage}`);
     currentKeyboard.keyPush(setting);
   }
   if (event.code === 'Tab') {
@@ -317,7 +316,7 @@ const mousePress = (event) => {
       } else {
         setting.currentLanguage = 'eng';
       }
-      window.sessionStorage.setItem('lang', setting.currentLanguage);
+      window.sessionStorage.setItem('keyLan', setting.currentLanguage);
       currentKeyboard.keyPush(setting);
     }
     ctrlKey = false;
@@ -330,7 +329,7 @@ const mousePress = (event) => {
       } else {
         setting.currentLanguage = 'eng';
       }
-      window.sessionStorage.setItem('lang', setting.currentLanguage);
+      window.sessionStorage.setItem('keyLan', setting.currentLanguage);
       currentKeyboard.keyPush(setting);
     }
     altKey = false;


### PR DESCRIPTION

    Task: https://github.com/rolling-scopes-school/tasks/blob/master/tasks/virtual-keyboard/virtual-keyboard-en.md
    Screenshot:

![Снимок](https://user-images.githubusercontent.com/100614240/167573249-54b99c83-3b13-4b27-8e91-124be4cc2fb4.PNG)


    Done 10.05.2022 / deadline 10.05.2022
    Score: 110/ 110

Minimal scope

    he generation of DOM elements is implemented. body in the index.html is empty (can contain only script tag): +20
    pressing a key on a physical keyboard highlights the key on the virtual keyboard (you should check keystrokes of numbers, letters, punctuation marks, backspace, del (if it's present), enter, shift, alt, ctrl, tab, caps lock, space, arrow keys: +10

Basic scope

    switching keyboard layouts between English and another language is implemented. Selected language should be saved and used on page reload. A keyboard shortcut for switching a language should be specified on the page: +15
    mouse clicks on buttons of the virtual keyboard or pressing buttons on a physical keyboard inputs characters to the input field (text area): +15

Extra scope

    animation of pressing a key is implemented

Technical requirements

    usage of ES6+ features (classes, property destructuring, etc): +15
    usage of ESLint: +10
    Requirements to the repository, commits and pull request are met (+10)

Penalties

    there're errors related to the executable code (errors like favicon.ico: Failed to load resource: the server responded with a status of 404 are not taken into account) or there're eslint-config-airbnb-base warnings: -15
